### PR TITLE
docs: Fix Urls import path in Templates guide

### DIFF
--- a/src/md-pages/v0.2/templates.md
+++ b/src/md-pages/v0.2/templates.md
@@ -164,7 +164,7 @@ Linking to other pages in your application is a frequent requirement, and hardco
 
 ```rust
 use cot::request::Request;
-use cot::request::extractors::Urls;
+use cot::router::Urls;
 use cot::response::{Response, ResponseExt};
 use cot::router::{Router, Route};
 use cot::{Body, StatusCode};


### PR DESCRIPTION
In the ["Templates" section of the guide](https://cot.rs/guide/latest/templates/), the import for Urls is written as `use cot::request::extractors::Urls;`. This yields a compilation error for me:

```

 1  error[E0603]: struct `Urls` is private
   --> src/main.rs:10:31
    |
 10 | use cot::request::extractors::Urls;
    |                               ^^^^ private struct
    |
 note: the struct `Urls` is defined here
   --> /home/julien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cot-0.2.0/src/request/extractors.rs:66:5
    |
 66 | use crate::router::Urls;
    |     ^^^^^^^^^^^^^^^^^^^
 help: import `Urls` directly
    |
 10 | use cot::router::Urls;
    |     ~~~~~~~~~~~~~~~~~

```

Changing to `cote::router::Urls` fixes that.
