### PR TITLE
Feat: Highlight current active version selected in guide page.

### DIFF
--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -1,253 +1,270 @@
 body {
-  scroll-behavior: smooth;
+    scroll-behavior: smooth;
 }
 
 .display-5 {
-  font-family: "Parkinsans", serif;
-  font-optical-sizing: auto;
-  font-weight: 300;
-  font-style: normal;
+    font-family: "Parkinsans", serif;
+    font-optical-sizing: auto;
+    font-weight: 300;
+    font-style: normal;
 }
 
 #icon-grid {
-  line-height: 1.75rem;
+    line-height: 1.75rem;
 }
 
 #icon-grid .bi {
-  $icon-grid-icon-size: 2.25rem;
+    $icon-grid-icon-size: 2.25rem;
 
-  margin-right: .8em;
-  margin-top: -.25rem;
+    margin-right: 0.8em;
+    margin-top: -0.25rem;
 
-  min-width: $icon-grid-icon-size;
-  max-width: $icon-grid-icon-size;
-  height: $icon-grid-icon-size;
+    min-width: $icon-grid-icon-size;
+    max-width: $icon-grid-icon-size;
+    height: $icon-grid-icon-size;
 
-  color: #e46914;
+    color: #e46914;
 }
 
 .main-lead {
-  background-image: linear-gradient(to right bottom, #0f172a, #2d3d57);
-  color: #f8f9fa;
+    background-image: linear-gradient(to right bottom, #0f172a, #2d3d57);
+    color: #f8f9fa;
 
-  margin-top: -3.5rem;
-  padding-top: 7.5rem;
-  padding-bottom: 6rem;
+    margin-top: -3.5rem;
+    padding-top: 7.5rem;
+    padding-bottom: 6rem;
 }
 
 .theme-bg {
-  background-color: #0f172a;
-  color: #f8f9fa;
+    background-color: #0f172a;
+    color: #f8f9fa;
 
-  $theme-bg-text-color: #adb5bd;
+    $theme-bg-text-color: #adb5bd;
 
-  .text-body-secondary {
-    color: $theme-bg-text-color;
-  }
-
-  a.text-body-secondary {
-    &:hover {
-      color: tint-color($theme-bg-text-color, 50%);
+    .text-body-secondary {
+        color: $theme-bg-text-color;
     }
-  }
+
+    a.text-body-secondary {
+        &:hover {
+            color: tint-color($theme-bg-text-color, 50%);
+        }
+    }
 }
 
 .btn.btn-primary {
-  --bs-btn-color: #fff;
+    --bs-btn-color: #fff;
 
-  &:hover, &:focus-visible {
-    $btn-primary-bg-color-hover: #ea580c;
+    &:hover,
+    &:focus-visible {
+        $btn-primary-bg-color-hover: #ea580c;
 
-    background-color: $btn-primary-bg-color-hover;
-    border-color: $btn-primary-bg-color-hover;
-    --bs-btn-hover-color: #fff;
-  }
+        background-color: $btn-primary-bg-color-hover;
+        border-color: $btn-primary-bg-color-hover;
+        --bs-btn-hover-color: #fff;
+    }
 
-  &:active {
-    $btn-primary-bg-color-active: shade-color($primary, 30%);
+    &:active {
+        $btn-primary-bg-color-active: shade-color($primary, 30%);
 
-    background-color: $btn-primary-bg-color-active;
-    border-color: $btn-primary-bg-color-active;
-    --bs-btn-active-color: #fff;
-  }
+        background-color: $btn-primary-bg-color-active;
+        border-color: $btn-primary-bg-color-active;
+        --bs-btn-active-color: #fff;
+    }
 }
 
 .btn-lead {
-  --bs-btn-padding-y: .75rem;
-  --bs-btn-padding-x: 2rem;
-  --bs-btn-font-size: 1.2rem;
-  font-weight: 600;
+    --bs-btn-padding-y: 0.75rem;
+    --bs-btn-padding-x: 2rem;
+    --bs-btn-font-size: 1.2rem;
+    font-weight: 600;
 }
 
 .btn.btn-lead-secondary {
-  $btn-lead-secondary-bg-color: #334155;
-  --bs-btn-focus-shadow-rgb: #{to-rgb(tint-color($btn-lead-secondary-bg-color, 40%))};
+    $btn-lead-secondary-bg-color: #334155;
+    --bs-btn-focus-shadow-rgb: #{to-rgb(
+            tint-color($btn-lead-secondary-bg-color, 40%)
+        )};
 
-  background-color: $btn-lead-secondary-bg-color;
-  border-color: $btn-lead-secondary-bg-color;
-  --bs-btn-color: #fff;
+    background-color: $btn-lead-secondary-bg-color;
+    border-color: $btn-lead-secondary-bg-color;
+    --bs-btn-color: #fff;
 
-  &:hover, &:focus-visible {
-    $btn-lead-secondary-bg-color-hover: tint-color($btn-lead-secondary-bg-color, 10%);
+    &:hover,
+    &:focus-visible {
+        $btn-lead-secondary-bg-color-hover: tint-color(
+            $btn-lead-secondary-bg-color,
+            10%
+        );
 
-    background-color: $btn-lead-secondary-bg-color-hover;
-    border-color: $btn-lead-secondary-bg-color-hover;
-    --bs-btn-hover-color: #fff;
-  }
+        background-color: $btn-lead-secondary-bg-color-hover;
+        border-color: $btn-lead-secondary-bg-color-hover;
+        --bs-btn-hover-color: #fff;
+    }
 
-  &:active {
-    $btn-lead-secondary-bg-color-active: tint-color($btn-lead-secondary-bg-color, 20%);
+    &:active {
+        $btn-lead-secondary-bg-color-active: tint-color(
+            $btn-lead-secondary-bg-color,
+            20%
+        );
 
-    background-color: $btn-lead-secondary-bg-color-active;
-    border-color: $btn-lead-secondary-bg-color-active;
-    --bs-btn-active-color: #fff;
-  }
+        background-color: $btn-lead-secondary-bg-color-active;
+        border-color: $btn-lead-secondary-bg-color-active;
+        --bs-btn-active-color: #fff;
+    }
 }
 
 .navbar {
-  font-family: "Convergence", serif;
+    font-family: "Convergence", serif;
 }
 
 .cot-toc {
-  #page-toc {
-    padding-right: 1rem;
-  }
-
-  ul {
-    list-style: none;
-    padding-left: 1rem;
-
-    li {
-      margin: .2rem 0;
+    #page-toc {
+        padding-right: 1rem;
     }
-  }
 
-  nav {
-    font-size: .875rem;
+    ul {
+        list-style: none;
+        padding-left: 1rem;
 
-    a {
-      color: inherit;
-      text-decoration: none;
-
-      &:hover {
-        color: $primary;
-      }
-
-      &.active {
-        color: $primary;
-      }
+        li {
+            margin: 0.2rem 0;
+        }
     }
-  }
+
+    nav {
+        font-size: 0.875rem;
+
+        a {
+            color: inherit;
+            text-decoration: none;
+
+            &:hover {
+                color: $primary;
+            }
+
+            &.active {
+                color: $primary;
+            }
+        }
+    }
 }
 
 @include media-breakpoint-up(lg) {
-  .sticky-sidebar {
-    position: sticky;
-    top: 1rem;
-    right: 0;
-    height: calc(100vh - 3rem);
-    overflow-y: auto;
-    max-width: 20%;
-  }
+    .sticky-sidebar {
+        position: sticky;
+        top: 1rem;
+        right: 0;
+        height: calc(100vh - 3rem);
+        overflow-y: auto;
+        max-width: 20%;
+        min-width: 11.25rem;
+    }
 }
 
 .guide-chapters {
-  ul {
-    @extend .list-unstyled;
+    ul {
+        @extend .list-unstyled;
 
-    li {
-      margin: .2rem 0;
-    }
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
-
-    &:hover {
-      color: $primary;
-      text-decoration: underline;
+        li {
+            margin: 0.2rem 0;
+        }
     }
 
-    &.active {
-      color: $primary;
+    a {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover {
+            color: $primary;
+            text-decoration: underline;
+        }
+
+        &.active {
+            color: $primary;
+        }
     }
-  }
 }
 
 .cot-guide {
-  // Allow the code blocks inside guide to overflow
-  min-width: 0;
+    // Allow the code blocks inside guide to overflow
+    min-width: 0;
 
-  p, ul, ol, table {
-    font-family: $font-family-serif;
-  }
+    p,
+    ul,
+    ol,
+    table {
+        font-family: $font-family-serif;
+    }
 
-  h2 {
-    margin-top: 2rem;
-  }
+    h2 {
+        margin-top: 2rem;
+    }
 
-  code {
-    white-space: pre;
-  }
+    code {
+        white-space: pre;
+    }
 }
 
 .anchor-link {
-  margin-left: calc(-0.6em - .9rem);
-  padding: 0 .5rem;
-  font-weight: 400;
-  color: $primary;
-  text-decoration: none;
-  opacity: 0;
+    margin-left: calc(-0.6em - 0.9rem);
+    padding: 0 0.5rem;
+    font-weight: 400;
+    color: $primary;
+    text-decoration: none;
+    opacity: 0;
 
-  &::after {
-    content: "#";
-  }
+    &::after {
+        content: "#";
+    }
 }
 
-.anchor-link:focus, .anchor-link:hover, :hover > .anchor-link, :target > .anchor-link {
-  opacity: 1;
+.anchor-link:focus,
+.anchor-link:hover,
+:hover > .anchor-link,
+:target > .anchor-link {
+    opacity: 1;
 }
 
 :target {
-  scroll-margin-top: 1rem;
-  background-color: transparentize($primary, 0.7);
+    scroll-margin-top: 1rem;
+    background-color: transparentize($primary, 0.7);
 }
 
 button.navbar-toggler {
-  height: 100%;
-  border: 0;
+    height: 100%;
+    border: 0;
 }
 
 @include media-breakpoint-up(lg) {
-  .collapse#page-toc-contents {
-    display: block;
-  }
+    .collapse#page-toc-contents {
+        display: block;
+    }
 }
 
 @include media-breakpoint-down(lg) {
-  #page-toc-contents nav {
-    margin-top: .5rem;
-    padding: .75rem .75rem 0 .75rem;
-    background-color: var(--bs-tertiary-bg);
-    border: 1px solid var(--bs-border-color);
-    border-radius: var(--bs-border-radius);
-  }
+    #page-toc-contents nav {
+        margin-top: 0.5rem;
+        padding: 0.75rem 0.75rem 0 0.75rem;
+        background-color: var(--bs-tertiary-bg);
+        border: 1px solid var(--bs-border-color);
+        border-radius: var(--bs-border-radius);
+    }
 }
 
 .bi {
-  width: 1em;
-  height: 1em;
-  vertical-align: -.125em;
-  fill: currentcolor;
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.125em;
+    fill: currentcolor;
 }
 
 .navbar-brand img {
-  transform: scale(1.75);
-  margin-right: .75rem;
-  margin-top: -.15rem;
+    transform: scale(1.75);
+    margin-right: 0.75rem;
+    margin-top: -0.15rem;
 }
 
 .version-switcher {
-  min-width: 5em;
+    min-width: 5em;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ struct GuideTemplate<'a> {
     guide: &'a MdPage,
     versions: &'static [&'static str],
     version: &'a str,
+    active_versions: Vec<bool>,
     base_context: &'a BaseContext,
     prev: Option<&'a MdPageLink>,
     next: Option<&'a MdPageLink>,
@@ -123,11 +124,15 @@ fn page_response(base_context: BaseContext, version: &str, page: &str) -> cot::R
     let guide = guide_map.get(page).ok_or_else(cot::Error::not_found)?;
     let (prev, next) = get_prev_next_link(&link_categories, page);
 
+    // let active_versions = ALL_VERSIONS.iter().map(|v| v == file_version).collect();
+    let active_versions = ALL_VERSIONS.iter().map(|&v| v == version).collect();
+
     let guide_template = GuideTemplate {
         link_categories: &link_categories,
         guide,
         versions: ALL_VERSIONS,
         version,
+        active_versions,
         base_context: &base_context,
         prev,
         next,

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -1,172 +1,185 @@
-{%- let urls = &base_context.urls -%}
+    {%- let urls = &base_context.urls -%}
 
-<!DOCTYPE html>
-<html lang="en" class="h-100">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="Mateusz Maćkowski and Cot contributors">
-    <meta name="keywords" content="Rust, Cot, web, framework, open-source">
-    <meta name="generator" content="cot-site based on Cot framework">
-    <title>{% block title %}{% endblock %} | Cot</title>
+    <!DOCTYPE html>
+    <html lang="en" class="h-100">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="author" content="Mateusz Maćkowski and Cot contributors">
+        <meta name="keywords" content="Rust, Cot, web, framework, open-source">
+        <meta name="generator" content="cot-site based on Cot framework">
+        <title>{% block title %}{% endblock %} | Cot</title>
 
-    <script src="/static/js/color-modes.js"></script>
-    <link href="/static/css/main.css" rel="stylesheet">
+        <!-- Open Graph Meta Tags -->
+        <meta property="og:title" content="Cot">
+        <meta property="og:description" content="The Rust web framework for lazy developers. Build secure, type-safe web apps with ease.">
+        <meta property="og:image" content="https://cot.rs/static/images/favicon-512.png">
+        <meta property="og:url" content="https://cot.rs">
+        <meta property="og:type" content="website">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Convergence&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Parkinsans:wght@300&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link href="https://fonts.googleapis.com/css2?family=Convergence&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Parkinsans:wght@300&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet"></noscript>
+        <!-- Twitter/X Card Meta Tags -->
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:title" content="Cot">
+        <meta name="twitter:description" content="The Rust web framework for lazy developers. Build secure, type-safe web apps with ease.">
+        <meta name="twitter:image" content="https://cot.rs/static/images/favicon-512.png">
 
-    <link rel="alternate icon" type="image/png" href="/static/images/favicon-32.png">
-    <link rel="icon" type="image/svg+xml" href="/static/images/favicon.svg">
-    <link rel="apple-touch-icon" href="/static/images/favicon-180.png" sizes="180x180">
-    <link rel="manifest" href="/static/images/site.webmanifest">
-    {%- block head -%}{%- endblock -%}
-</head>
-<body class="bg-body d-flex flex-column h-100">
+        <script src="/static/js/color-modes.js"></script>
+        <link href="/static/css/main.css" rel="stylesheet">
 
-{%- include "icons/common_icons.svg" -%}
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="preload" href="https://fonts.googleapis.com/css2?family=Convergence&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Parkinsans:wght@300&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link href="https://fonts.googleapis.com/css2?family=Convergence&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Parkinsans:wght@300&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet"></noscript>
 
-<nav class="navbar navbar-expand-lg fixed-top{% block navbar_classes %} border-bottom theme-bg{% endblock %}" data-bs-theme="dark">
-    <div class="container">
-        {%- if guide is defined -%}
-        <button class="navbar-toggler p-2 me-1" type="button" data-bs-toggle="offcanvas" data-bs-target="#cot-guide-chapters" aria-controls="cot-guide-chapters" aria-label="Toggle guide navigation">
-            <svg class="bi"><use href="#list"></use></svg>
-            <span class="d-none fs-6 pe-1">Browse</span>
-        </button>
-        {%- endif -%}
+        <link rel="alternate icon" type="image/png" href="/static/images/favicon-32.png">
+        <link rel="icon" type="image/svg+xml" href="/static/images/favicon.svg">
+        <link rel="apple-touch-icon" href="/static/images/favicon-180.png" sizes="180x180">
+        <link rel="manifest" href="/static/images/site.webmanifest">
+        {%- block head -%}{%- endblock -%}
+    </head>
+    <body class="bg-body d-flex flex-column h-100">
 
-        <a class="navbar-brand" href="{{ cot::reverse!(urls, "index")? }}" aria-label="Go to homepage"><img src="/static/images/cot-dark.svg" alt="" width="30" height="24">Cot</a>
-        <button class="ms-auto navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#cot-offcanvas-navbar" aria-controls="cot-offcanvas-navbar" aria-label="Toggle navigation">
-            <svg class="bi"><use href="#three-dots"></use></svg>
-        </button>
-        <div class="offcanvas offcanvas-end" tabindex="-1" id="cot-offcanvas-navbar" aria-labelledby="cot-offcanvas-navbar-label">
-            <div class="offcanvas-header">
-                <h5 class="offcanvas-title" id="cot-offcanvas-navbar-label">Cot</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    {%- include "icons/common_icons.svg" -%}
+
+    <nav class="navbar navbar-expand-lg fixed-top{% block navbar_classes %} border-bottom theme-bg{% endblock %}" data-bs-theme="dark">
+        <div class="container">
+            {%- if guide is defined -%}
+            <button class="navbar-toggler p-2 me-1" type="button" data-bs-toggle="offcanvas" data-bs-target="#cot-guide-chapters" aria-controls="cot-guide-chapters" aria-label="Toggle guide navigation">
+                <svg class="bi"><use href="#list"></use></svg>
+                <span class="d-none fs-6 pe-1">Browse</span>
+            </button>
+            {%- endif -%}
+
+            <a class="navbar-brand" href="{{ cot::reverse!(urls, "index")? }}" aria-label="Go to homepage"><img src="/static/images/cot-dark.svg" alt="" width="30" height="24">Cot</a>
+            <button class="ms-auto navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#cot-offcanvas-navbar" aria-controls="cot-offcanvas-navbar" aria-label="Toggle navigation">
+                <svg class="bi"><use href="#three-dots"></use></svg>
+            </button>
+            <div class="offcanvas offcanvas-end" tabindex="-1" id="cot-offcanvas-navbar" aria-labelledby="cot-offcanvas-navbar-label">
+                <div class="offcanvas-header">
+                    <h5 class="offcanvas-title" id="cot-offcanvas-navbar-label">Cot</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </div>
+                <div class="offcanvas-body">
+                    {%- let route_name = base_context.route_name -%}
+                    <ul class="navbar-nav flex-grow-1 pe-3">
+                        <li class="nav-item">
+                            <a class="nav-link{% if route_name == "guide" || route_name == "guide_version" || route_name == "guide_page" %} active{% endif %}" href="{{ cot::reverse!(urls, "guide")? }}">Guide</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="https://docs.rs/cot">Docs</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link{% if route_name == "faq" %} active{% endif %}" href="{{ cot::reverse!(urls, "faq")? }}">FAQ</a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+                        <li class="nav-item">
+                            <a class="nav-link" href="https://github.com/cot-rs/cot" aria-label="Cot repository on GitHub">
+                                <svg class="bi"><use href="#github"></use></svg><span class="d-lg-none ms-2">GitHub</span>
+                            </a>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center" id="cot-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown" data-bs-display="static" aria-label="Toggle theme (dark)">
+                                <svg class="bi my-1 theme-icon-active"><use href="#moon-stars-fill"></use></svg>
+                                <span class="d-lg-none ms-2" id="cot-theme-text">Toggle theme</span>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end dropdown-menu-xxl-start">
+                                <li>
+                                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
+                                        <svg class="bi me-2"><use href="#sun-fill"></use></svg>Light
+                                    </button>
+                                </li>
+                                <li>
+                                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
+                                        <svg class="bi me-2"><use href="#moon-stars-fill"></use></svg>Dark
+                                    </button>
+                                </li>
+                                <li>
+                                    <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
+                                        <svg class="bi me-2"><use href="#circle-half"></use></svg>Auto
+                                    </button>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
             </div>
-            <div class="offcanvas-body">
-                {%- let route_name = base_context.route_name -%}
-                <ul class="navbar-nav flex-grow-1 pe-3">
-                    <li class="nav-item">
-                        <a class="nav-link{% if route_name == "guide" || route_name == "guide_version" || route_name == "guide_page" %} active{% endif %}" href="{{ cot::reverse!(urls, "guide")? }}">Guide</a>
+        </div>
+    </nav>
+
+    <main>{% block content %}{% endblock %}</main>
+
+    <footer class="border-top theme-bg mt-auto">
+        <div class="container row row-cols-1 row-cols-sm-2 row-cols-lg-5 py-5 mx-auto">
+            <div class="col mb-3 text-start text-lg-center">
+                <a href="/" class="d-block mb-3 link-body-emphasis text-decoration-none" title="Go to Cot homepage">
+                    <img src="/static/images/cot-dark.svg" alt="" width="80" height="64" class="mx-lg-auto d-block">
+                </a>
+                <p class="text-body-secondary">&copy; 2024-2025 Cot contributors</p>
+            </div>
+
+            <div class="col mb-3">
+                <h5>Learn More</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item mb-2">
+                        <a href="{{ cot::reverse!(urls, "licenses")? }}" class="nav-link p-0 text-body-secondary">Licenses</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="https://docs.rs/cot">Docs</a>
+                    <li class="nav-item mb-2">
+                        <a href="{{ cot::reverse!(urls, "faq")? }}" class="nav-link p-0 text-body-secondary">FAQ</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link{% if route_name == "faq" %} active{% endif %}" href="{{ cot::reverse!(urls, "faq")? }}">FAQ</a>
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot/blob/master/CODE_OF_CONDUCT.md" class="nav-link p-0 text-body-secondary">Code of Conduct</a>
                     </li>
                 </ul>
-                <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
-                    <li class="nav-item">
-                        <a class="nav-link" href="https://github.com/cot-rs/cot" aria-label="Cot repository on GitHub">
-                            <svg class="bi"><use href="#github"></use></svg><span class="d-lg-none ms-2">GitHub</span>
-                        </a>
+            </div>
+            <div class="col mb-3">
+                <h5>Get Involved</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot/blob/master/CONTRIBUTING.md" class="nav-link p-0 text-body-secondary">Contribute to Cot</a>
                     </li>
-                    <li class="nav-item dropdown">
-                        <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center" id="cot-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown" data-bs-display="static" aria-label="Toggle theme (dark)">
-                            <svg class="bi my-1 theme-icon-active"><use href="#moon-stars-fill"></use></svg>
-                            <span class="d-lg-none ms-2" id="cot-theme-text">Toggle theme</span>
-                        </button>
-                        <ul class="dropdown-menu dropdown-menu-end dropdown-menu-xxl-start">
-                            <li>
-                                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
-                                    <svg class="bi me-2"><use href="#sun-fill"></use></svg>Light
-                                </button>
-                            </li>
-                            <li>
-                                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
-                                    <svg class="bi me-2"><use href="#moon-stars-fill"></use></svg>Dark
-                                </button>
-                            </li>
-                            <li>
-                                <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
-                                    <svg class="bi me-2"><use href="#circle-half"></use></svg>Auto
-                                </button>
-                            </li>
-                        </ul>
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot/issues/new" class="nav-link p-0 text-body-secondary">Submit a bug</a>
+                    </li>
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot/blob/master/SECURITY.md" class="nav-link p-0 text-body-secondary">Security</a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="col mb-3">
+                <h5>Get Help</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot/discussions/categories/q-a" class="nav-link p-0 text-body-secondary">GitHub Discussions</a>
+                    </li>
+                    <li class="nav-item mb-2">
+                        <a href="https://stackoverflow.com/tags/cot" class="nav-link p-0 text-body-secondary">Stack Overflow</a>
+                    </li>
+                    <li class="nav-item mb-2">
+                        <a href="https://discord.cot.rs/" class="nav-link p-0 text-body-secondary">Discord</a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="col mb-3">
+                <h5>Community</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/cot-rs/cot" class="nav-link p-0 text-body-secondary">GitHub</a>
+                    </li>
+                    <li class="nav-item mb-2">
+                        <a href="https://discord.cot.rs/" class="nav-link p-0 text-body-secondary">Discord</a>
+                    </li>
+                    <li class="nav-item mb-2">
+                        <a href="https://github.com/sponsors/cot-rs/" class="nav-link p-0 text-body-secondary">Sponsor Cot</a>
                     </li>
                 </ul>
             </div>
         </div>
-    </div>
-</nav>
+    </footer>
 
-<main>{% block content %}{% endblock %}</main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
-<footer class="border-top theme-bg mt-auto">
-    <div class="container row row-cols-1 row-cols-sm-2 row-cols-lg-5 py-5 mx-auto">
-        <div class="col mb-3 text-start text-lg-center">
-            <a href="/" class="d-block mb-3 link-body-emphasis text-decoration-none" title="Go to Cot homepage">
-                <img src="/static/images/cot-dark.svg" alt="" width="80" height="64" class="mx-lg-auto d-block">
-            </a>
-            <p class="text-body-secondary">&copy; 2024-2025 Cot contributors</p>
-        </div>
-
-        <div class="col mb-3">
-            <h5>Learn More</h5>
-            <ul class="nav flex-column">
-                <li class="nav-item mb-2">
-                    <a href="{{ cot::reverse!(urls, "licenses")? }}" class="nav-link p-0 text-body-secondary">Licenses</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="{{ cot::reverse!(urls, "faq")? }}" class="nav-link p-0 text-body-secondary">FAQ</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot/blob/master/CODE_OF_CONDUCT.md" class="nav-link p-0 text-body-secondary">Code of Conduct</a>
-                </li>
-            </ul>
-        </div>
-        <div class="col mb-3">
-            <h5>Get Involved</h5>
-            <ul class="nav flex-column">
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot/blob/master/CONTRIBUTING.md" class="nav-link p-0 text-body-secondary">Contribute to Cot</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot/issues/new" class="nav-link p-0 text-body-secondary">Submit a bug</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot/blob/master/SECURITY.md" class="nav-link p-0 text-body-secondary">Security</a>
-                </li>
-            </ul>
-        </div>
-
-        <div class="col mb-3">
-            <h5>Get Help</h5>
-            <ul class="nav flex-column">
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot/discussions/categories/q-a" class="nav-link p-0 text-body-secondary">GitHub Discussions</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://stackoverflow.com/tags/cot" class="nav-link p-0 text-body-secondary">Stack Overflow</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://discord.cot.rs/" class="nav-link p-0 text-body-secondary">Discord</a>
-                </li>
-            </ul>
-        </div>
-
-        <div class="col mb-3">
-            <h5>Community</h5>
-            <ul class="nav flex-column">
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/cot-rs/cot" class="nav-link p-0 text-body-secondary">GitHub</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://discord.cot.rs/" class="nav-link p-0 text-body-secondary">Discord</a>
-                </li>
-                <li class="nav-item mb-2">
-                    <a href="https://github.com/sponsors/cot-rs/" class="nav-link p-0 text-body-secondary">Sponsor Cot</a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</footer>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-
-</body>
-</html>
+    </body>
+    </html>

--- a/templates/_guide_chapters.html
+++ b/templates/_guide_chapters.html
@@ -5,7 +5,8 @@
     <ul class="dropdown-menu">
         {%- for ver in versions -%}
         <li><a
-                class="dropdown-item"
+                {# class="dropdown-item{% if ver == version %} active{% endif %}" #}
+                class="dropdown-item{% if active_versions[loop.index0] %} active{% endif %}"
                 href="{{ cot::reverse!(urls, "guide_version", version = ver)? }}"
             >{{ ver }}</a></li>
         {%- endfor -%}


### PR DESCRIPTION
PR for issue #18

Initially, I added a conditional comparison in the dropdown loop:
```html
<ul class="dropdown-menu">
    {%- for ver in versions -%}
    <li><a
            class="dropdown-item{% if ver == version %} active{% endif %}"
            href="{{ cot::reverse!(urls, "guide_version", version = ver)? }}"
        >{{ ver }}</a></li>
    {%- endfor -%}
</ul>
```

But was getting this error:
```
error[E0277]: can't compare `&str` with `str`
  --> src/main.rs:54:17
   |
54 | #[derive(Debug, Template)]
   |                 ^^^^^^^^ no implementation for `&str == str`
   |
   = help: the trait `PartialEq<str>` is not implemented for `&str`
   = note: required for `&&str` to implement `PartialEq<&str>`
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
   ```
  I think `rinja` was failing to generate valid code for `ver == version` from GuideTemplate struct’s Template derive macro.
   
  So added a workaround by checking for active version in `main.rs` and avoiding the template comparison.
  
  This is the current UI.

![Screenshot from 2025-05-01 12-47-55](https://github.com/user-attachments/assets/cedada19-1193-44ad-98cf-9b2b455ca9e0)
