### PR TITLE
Improve Build script error

### DIFF
--- a/cot-site-macros/build.rs
+++ b/cot-site-macros/build.rs
@@ -34,6 +34,6 @@ fn add_syntax_highlighting_from_folder(builder: &mut SyntaxSetBuilder, path: &st
     builder
         .add_from_folder(format!("../syntax-highlighting/{path}"), true)
         .unwrap_or_else(|err| {
-            panic!("failed to add {path} syntax highlighting\n original error: {err}")
+            panic!("failed to add {path} syntax highlighting: {err}")
         })
 }

--- a/cot-site-macros/build.rs
+++ b/cot-site-macros/build.rs
@@ -33,7 +33,5 @@ fn build_syntax_highlighting_defs() {
 fn add_syntax_highlighting_from_folder(builder: &mut SyntaxSetBuilder, path: &str) {
     builder
         .add_from_folder(format!("../syntax-highlighting/{path}"), true)
-        .unwrap_or_else(|err| {
-            panic!("failed to add {path} syntax highlighting: {err}")
-        })
+        .unwrap_or_else(|err| panic!("failed to add {path} syntax highlighting: {err}"))
 }

--- a/cot-site-macros/build.rs
+++ b/cot-site-macros/build.rs
@@ -33,5 +33,7 @@ fn build_syntax_highlighting_defs() {
 fn add_syntax_highlighting_from_folder(builder: &mut SyntaxSetBuilder, path: &str) {
     builder
         .add_from_folder(format!("../syntax-highlighting/{path}"), true)
-        .unwrap_or_else(|_| panic!("failed to add {path} syntax highlighting"))
+        .unwrap_or_else(|err| {
+            panic!("failed to add {path} syntax highlighting\n original error: {err}")
+        })
 }


### PR DESCRIPTION
Oftentimes, when the syntax highlighting git submodule is out of sync, it's not clear how to fix the issue until you know the original error