### PR TITLE
ci: run the pipeline for the entire workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo +${{ matrix.rust }} nextest run --workspace
 
       - name: Test docs
-        run: cargo +${{ matrix.rust }} test
+        run: cargo +${{ matrix.rust }} test --workspace --doc
 
   clippy:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository
@@ -78,7 +78,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: cargo clippy --no-deps --
+        run: cargo clippy --workspace --no-deps -- -D warnings
 
   rustfmt:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository

--- a/cot-site-common/Cargo.toml
+++ b/cot-site-common/Cargo.toml
@@ -6,6 +6,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 comrak.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 semver.workspace = true
 thiserror.workspace = true

--- a/cot-site-common/src/utils.rs
+++ b/cot-site-common/src/utils.rs
@@ -23,6 +23,7 @@ impl Version {
     ///
     /// # Example
     /// ```
+    /// # use cot_site_common::Version;
     /// let v = Version::new(0, 5, 0);
     /// assert_eq!(v.to_string(), "0.5.0");
     /// ```
@@ -34,6 +35,7 @@ impl Version {
     ///
     /// # Example
     /// ```
+    /// # use cot_site_common::Version;
     /// let v = Version::new(0, 5, 0);
     /// assert_eq!(v.major(), 0);
     /// ```
@@ -45,6 +47,7 @@ impl Version {
     ///
     /// # Example
     /// ```
+    /// # use cot_site_common::Version;
     /// let v = Version::new(0, 5, 0);
     /// assert_eq!(v.minor(), 5);
     /// ```
@@ -56,6 +59,7 @@ impl Version {
     ///
     /// # Example
     /// ```
+    /// # use cot_site_common::Version;
     /// let v = Version::new(0, 5, 0);
     /// assert_eq!(v.patch(), 0);
     /// ```

--- a/cot-site-macros/src/md_pages/rendering.rs
+++ b/cot-site-macros/src/md_pages/rendering.rs
@@ -129,7 +129,7 @@ fn render_table_custom<'a>(
 /// suffix for required methods and the `method` suffix for provided methods.
 ///
 /// Examples
-/// ```
+/// ```text
 /// # reference to `foo` method of `Name` struct in `cot::a::b` module
 /// struct@cot::a::b::Name#method.foo -> https://docs.rs/cot/0.5.0/cot/a/b/struct.Name.html#method.foo
 /// # reference to `foo` required method of `Name` trait in `cot::a::b` module
@@ -145,7 +145,7 @@ fn render_table_custom<'a>(
 ///
 /// Examples:
 ///
-/// ```
+/// ```text
 /// # reference to a `url` field in the `DatabaseConfig` struct in the `cot::config` module.
 /// struct@cot::config::DatabaseConfig#structfield.url -> https://docs.rs/cot/0.5.0/cot/config/struct.DatabaseConfig.html/structfield.url
 /// ```


### PR DESCRIPTION
Looks like we accidentally did not set up the CI to work on the entire workspace. It was therefore running only for the main crate, and in the meantime we merged a few changes that were breaking the tests.

This fixes both the CI and the broken tests.