### PR TITLE
feat: add some code samples to the homepage

### DIFF
--- a/cot-site-macros/src/lib.rs
+++ b/cot-site-macros/src/lib.rs
@@ -2,9 +2,18 @@
 
 use proc_macro::TokenStream;
 
-use crate::md_pages::{ExternalMdPageInput, MdPageInput};
+use crate::md_pages::{CodeSampleInput, ExternalMdPageInput, MdPageInput};
 
 mod md_pages;
+
+#[proc_macro]
+pub fn code_sample(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+
+    let CodeSampleInput { lang, code } = syn::parse2(input).unwrap();
+
+    md_pages::quote_code_sample(&lang, &code).into()
+}
 
 #[proc_macro]
 pub fn md_page(input: TokenStream) -> TokenStream {

--- a/cot-site-macros/src/md_pages.rs
+++ b/cot-site-macros/src/md_pages.rs
@@ -38,6 +38,25 @@ impl Parse for ExternalMdPageInput {
     }
 }
 
+pub(super) struct CodeSampleInput {
+    pub(super) lang: String,
+    pub(super) code: String,
+}
+
+impl Parse for CodeSampleInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lang = input.parse::<LitStr>()?.value();
+        input.parse::<syn::Token![,]>()?;
+        let code = input.parse::<LitStr>()?.value();
+        Ok(Self { lang, code })
+    }
+}
+
+pub(super) fn quote_code_sample(lang: &str, code: &str) -> TokenStream {
+    let html = rendering::render_code_sample(lang, code);
+    quote! { #html }
+}
+
 fn read_md_page(link: &str) -> String {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let path = Path::new(&manifest_dir).join(link).with_extension("md");
@@ -111,15 +130,7 @@ pub(super) fn parse_md_page(prefix: &str, link: &str, version: &str) -> MdPage {
         sections: Mutex::new(vec![]),
     };
 
-    let syntax_highlighter = comrak::plugins::syntect::SyntectAdapterBuilder::new()
-        .css()
-        .syntax_set(
-            syntect::dumps::from_uncompressed_data(include_bytes!(
-                "../../syntax-highlighting/defs.bin"
-            ))
-            .expect("failed to load syntax set"),
-        )
-        .build();
+    let syntax_highlighter = rendering::build_syntax_highlighter();
     let render_plugins = comrak::options::RenderPlugins::builder()
         .codefence_syntax_highlighter(&syntax_highlighter)
         .heading_adapter(&heading_adapter)

--- a/cot-site-macros/src/md_pages/rendering.rs
+++ b/cot-site-macros/src/md_pages/rendering.rs
@@ -17,6 +17,68 @@ struct PageContext {
     version: Version,
 }
 
+pub(super) fn build_syntax_highlighter() -> comrak::plugins::syntect::SyntectAdapter {
+    comrak::plugins::syntect::SyntectAdapterBuilder::new()
+        .css()
+        .syntax_set(
+            syntect::dumps::from_uncompressed_data(include_bytes!(
+                "../../../syntax-highlighting/defs.bin"
+            ))
+            .expect("failed to load syntax set"),
+        )
+        .build()
+}
+
+pub(super) fn render_code_sample(lang: &str, code: &str) -> String {
+    let md = format!("```{lang}\n{code}\n```");
+
+    let mut options = Options::default();
+    options.render.r#unsafe = true;
+
+    let syntax_highlighter = build_syntax_highlighter();
+    let render_plugins = comrak::options::RenderPlugins::builder()
+        .codefence_syntax_highlighter(&syntax_highlighter)
+        .build();
+    let plugins = Plugins::builder().render(render_plugins).build();
+
+    let arena = Arena::new();
+    let root = parse_document(&arena, &md, &options);
+    let mut s = String::new();
+    format_document_with_formatter(
+        root,
+        &options,
+        &mut s,
+        &plugins,
+        format_node_code_sample,
+        (),
+    )
+    .unwrap();
+    s
+}
+
+fn format_node_code_sample<'a>(
+    context: &mut Context<()>,
+    node: &'a AstNode<'a>,
+    entering: bool,
+) -> Result<ChildRendering, fmt::Error> {
+    match node.data.borrow().value {
+        NodeValue::CodeBlock(ref cb) => render_code_block_plain(context, node, entering, cb),
+        _ => format_node_default(context, node, entering),
+    }
+}
+
+fn render_code_block_plain<'a>(
+    context: &mut Context<()>,
+    _node: &'a AstNode<'a>,
+    entering: bool,
+    cb: &NodeCodeBlock,
+) -> Result<ChildRendering, fmt::Error> {
+    let mut new_cb = cb.clone();
+    new_cb.literal = remove_hidden_lines(&cb.literal);
+    let node = AstNode::from(NodeValue::CodeBlock(Box::new(new_cb)));
+    format_node_default(context, &node, entering)
+}
+
 pub(super) fn markdown_to_html(
     md: &str,
     options: &Options,

--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -1,3 +1,11 @@
+:root, [data-bs-theme=light] {
+  --homepage-samples-background-color: #ebebeb;
+}
+
+[data-bs-theme=dark] {
+  --homepage-samples-background-color: #343434;
+}
+
 body {
   scroll-behavior: smooth;
 }
@@ -376,4 +384,14 @@ button.navbar-toggler {
 .guide-link.active {
   color: var(--bs-primary);
   font-weight: 500;
+}
+
+#homepage-samples{
+  .lead {
+    font-size: 1.35rem;
+  }
+
+  pre {
+    background-color: var(--homepage-samples-background-color);
+  }
 }

--- a/src/code_samples.rs
+++ b/src/code_samples.rs
@@ -1,0 +1,70 @@
+use cot_site_macros::code_sample;
+
+pub const ORM_CODE_SAMPLE: &str = code_sample!(
+    "rust",
+    r#"#[model]
+struct Customer {
+    #[model(primary_key)]
+    id: Auto<i64>,
+    #[model(unique)]
+    email: Email,
+    is_verified: bool,
+}
+
+let customer = query!(Customer, $email == email)
+    .get(&db)
+    .await?;"#
+);
+
+pub const FORMS_CODE_SAMPLE: &str = code_sample!(
+    "rust",
+    r#"#[derive(Debug, Form)]
+struct SignupForm {
+    #[form(opts(max_length = 100))]
+    username: String,
+    email: Email,
+    password: Password,
+}
+
+async fn signup(
+    RequestForm(form): RequestForm<SignupForm>,
+) -> cot::Result<Response> {
+    let form = form.unwrap();
+    // username, email, and password are already validated
+    DatabaseUser::create_user(&db, &form.username, &form.password).await?;
+    Ok(reverse_redirect!(urls, "index")?)
+}"#
+);
+
+pub const ADMIN_CODE_SAMPLE: &str = code_sample!(
+    "rust",
+    r#"#[derive(Debug, Clone, Form, AdminModel)]
+#[model]
+struct TodoItem {
+    #[model(primary_key)]
+    id: Auto<i32>,
+    title: String,
+}
+
+impl App for TodoApp {
+    fn admin_model_managers(&self) -> Vec<Box<dyn AdminModelManager>> {
+        vec![Box::new(DefaultAdminModelManager::<TodoItem>::new())]
+    }
+}"#
+);
+
+pub const JSON_CODE_SAMPLE: &str = code_sample!(
+    "rust",
+    r#"#[derive(Deserialize, schemars::JsonSchema)]
+struct AddRequest { a: i32, b: i32 }
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct AddResponse { result: i32 }
+
+async fn add(Json(req): Json<AddRequest>) -> Json<AddResponse> {
+    Json(AddResponse { result: req.a + req.b })
+}
+
+// Swagger UI is generated automatically from the types above
+Route::with_api_handler_and_name("/add/", api_post(add), "add");"#
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod code_samples;
 mod guides;
 mod search;
 mod template_util;

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,37 @@
     </div>
 </div>
 
-<div class="bg-body-tertiary">
+<div class="bg-body-secondary py-5">
+    <div class="container px-4 py-5">
+        <h2 class="pb-2 text-center">Less boilerplate, more building</h2>
+        <p class="lead text-center col-lg-8 mx-auto pb-3">A taste of what everyday Cot code looks like&nbsp;—&nbsp;type-safe, declarative, and free of ceremony.</p>
+
+        <div class="row row-cols-1 row-cols-lg-2 g-4 py-3">
+            <div class="col">
+                <h3 class="fw-bold mb-1 fs-5">Type-safe ORM queries</h3>
+                <p>Define a model once, then query it with the <code>query!</code> macro&nbsp;—&nbsp;fields and types are checked at compile time, not at runtime.</p>
+                {{ code_samples::ORM_CODE_SAMPLE|safe }}
+            </div>
+            <div class="col">
+                <h3 class="fw-bold mb-1 fs-5">Forms that validate themselves</h3>
+                <p><code>#[derive(Form)]</code> turns a struct into a fully validated HTML form, complete with types like <code>Email</code> and <code>Password</code> that guarantee well-formed data.</p>
+                {{ code_samples::FORMS_CODE_SAMPLE|safe }}
+            </div>
+            <div class="col">
+                <h3 class="fw-bold mb-1 fs-5">An admin panel for (almost) free</h3>
+                <p>Add <code>AdminModel</code> to any model and register it&nbsp;—&nbsp;Cot generates a full CRUD admin interface, no extra code required.</p>
+                {{ code_samples::ADMIN_CODE_SAMPLE|safe }}
+            </div>
+            <div class="col">
+                <h3 class="fw-bold mb-1 fs-5">JSON APIs with OpenAPI built in</h3>
+                <p>Derive <code>JsonSchema</code> on your request and response types, and Cot generates an interactive Swagger UI automatically&nbsp;—&nbsp;no separate spec to maintain.</p>
+                {{ code_samples::JSON_CODE_SAMPLE|safe }}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="bg-body-tertiary border-top">
     <div class="container mx-auto px-4 py-4 text-center">
         <h2 class="font-bold my-4">Ready to Get Started?</h2>
         <p class="mb-8">

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,101 +23,101 @@
     </div>
 </div>
 
-<div class="container px-4 py-5" id="icon-grid">
-    <h2 class="pb-2 text-center">Features</h2>
+<div class="container px-4 py-5" id="homepage-samples">
+    <h2 class="pb-2 text-center">Less crate hunting, more building</h2>
+    <p class="lead text-center col-lg-8 mx-auto pb-3">A taste of what everyday Cot code looks like&nbsp;—&nbsp;type-safe, declarative, and free of ceremony.</p>
 
-    <div class="row row-cols-1 row-cols-sm-1 row-cols-md-2 row-cols-lg-3 g-5 py-5">
-        <div class="col d-flex align-items-start">
-            {% include "icons/battery.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Batteries-included</h3>
-                <p>Cot delivers solutions to common web development challenges&nbsp;—&nbsp;so you can focus on bringing your ideas to life, instead of hunting down crates.</p>
-            </div>
+    <div class="row row-cols-1 row-cols-lg-2 g-4 py-3">
+        <div class="col">
+            <h3 class="fw-bold mb-1 fs-5">Type-safe ORM queries</h3>
+            <p>Define a model once, then query it with the <code>query!</code> macro&nbsp;—&nbsp;fields and types are checked at compile time, not at runtime.</p>
+            {{ code_samples::ORM_CODE_SAMPLE|safe }}
         </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/terminal.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Easy to use API</h3>
-                <p>Cot's API is designed to be easy to use and intuitive. Sensible defaults make it for easy rapid development, while the API is still empowering you when needed.</p>
-            </div>
+        <div class="col">
+            <h3 class="fw-bold mb-1 fs-5">Forms that validate themselves</h3>
+            <p><code>#[derive(Form)]</code> turns a struct into a fully validated HTML form, complete with types like <code>Email</code> and <code>Password</code> that guarantee well-formed data.</p>
+            {{ code_samples::FORMS_CODE_SAMPLE|safe }}
         </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/database.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">ORM integration</h3>
-                <p>Cot's integrated ORM provides a Rust-native database experience. Rust types guide your data model, while the ORM handles conversions and auto-generates migrations.</p>
-            </div>
+        <div class="col">
+            <h3 class="fw-bold mb-1 fs-5">An admin panel for (almost) free</h3>
+            <p>Add <code>AdminModel</code> to any model and register it&nbsp;—&nbsp;Cot generates a full CRUD admin interface, no extra code required.</p>
+            {{ code_samples::ADMIN_CODE_SAMPLE|safe }}
         </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/gauge.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Admin panel</h3>
-                <p>Built-in admin panel is here for effortless data management. Adding new models is simple, making it perfect for rapid prototyping.</p>
-            </div>
-        </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/shield.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Security</h3>
-                <p>Security should be the default, not an afterthought. Cot safeguards your app against modern threats, so you can focus on building, not bolting on security.</p>
-            </div>
-        </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/lightning.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Performance</h3>
-                <p>Enjoy machine-code speed with interpreted convenience&nbsp;—&nbsp;experience full-featured development without sacrificing performance.</p>
-            </div>
-        </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/book.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Documentation</h3>
-                <p>The documentation is a first-class citizen in Cot, making it always easy to find what you're looking for.</p>
-            </div>
-        </div>
-        <div class="col d-flex align-items-start">
-            {% include "icons/patch_check.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">Type safety</h3>
-                <p>Cot harnesses Rust's type system to catch errors early. From ORM to the templates, every component benefits from strong typing to prevent bugs.</p>
-            </div>
-        </div>
-        <div class="col d-none d-lg-flex align-items-start">
-            {% include "icons/braces.svg" %}
-            <div>
-                <h3 class="fw-bold mb-2 fs-4">JSON & OpenAPI</h3>
-                <p>Cot comes with first-class JSON handling right out of the box. Simply derive JSON traits to parse data or return responses, and automatically generate Swagger UI.</p>
-            </div>
+        <div class="col">
+            <h3 class="fw-bold mb-1 fs-5">JSON APIs with OpenAPI built in</h3>
+            <p>Derive <code>JsonSchema</code> on your request and response types, and Cot generates an interactive Swagger UI automatically&nbsp;—&nbsp;no separate spec to maintain.</p>
+            {{ code_samples::JSON_CODE_SAMPLE|safe }}
         </div>
     </div>
 </div>
 
-<div class="bg-body-secondary py-5">
-    <div class="container px-4 py-5">
-        <h2 class="pb-2 text-center">Less boilerplate, more building</h2>
-        <p class="lead text-center col-lg-8 mx-auto pb-3">A taste of what everyday Cot code looks like&nbsp;—&nbsp;type-safe, declarative, and free of ceremony.</p>
+<div class="bg-body-secondary">
+    <div class="container px-4 py-5" id="icon-grid">
+        <h2 class="pb-2 text-center">Features</h2>
 
-        <div class="row row-cols-1 row-cols-lg-2 g-4 py-3">
-            <div class="col">
-                <h3 class="fw-bold mb-1 fs-5">Type-safe ORM queries</h3>
-                <p>Define a model once, then query it with the <code>query!</code> macro&nbsp;—&nbsp;fields and types are checked at compile time, not at runtime.</p>
-                {{ code_samples::ORM_CODE_SAMPLE|safe }}
+        <div class="row row-cols-1 row-cols-sm-1 row-cols-md-2 row-cols-lg-3 g-5 py-5">
+            <div class="col d-flex align-items-start">
+                {% include "icons/battery.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Batteries-included</h3>
+                    <p>Cot delivers solutions to common web development challenges&nbsp;—&nbsp;so you can focus on bringing your ideas to life, instead of hunting down crates.</p>
+                </div>
             </div>
-            <div class="col">
-                <h3 class="fw-bold mb-1 fs-5">Forms that validate themselves</h3>
-                <p><code>#[derive(Form)]</code> turns a struct into a fully validated HTML form, complete with types like <code>Email</code> and <code>Password</code> that guarantee well-formed data.</p>
-                {{ code_samples::FORMS_CODE_SAMPLE|safe }}
+            <div class="col d-flex align-items-start">
+                {% include "icons/terminal.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Easy to use API</h3>
+                    <p>Cot's API is designed to be easy to use and intuitive. Sensible defaults make it for easy rapid development, while the API is still empowering you when needed.</p>
+                </div>
             </div>
-            <div class="col">
-                <h3 class="fw-bold mb-1 fs-5">An admin panel for (almost) free</h3>
-                <p>Add <code>AdminModel</code> to any model and register it&nbsp;—&nbsp;Cot generates a full CRUD admin interface, no extra code required.</p>
-                {{ code_samples::ADMIN_CODE_SAMPLE|safe }}
+            <div class="col d-flex align-items-start">
+                {% include "icons/database.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">ORM integration</h3>
+                    <p>Cot's integrated ORM provides a Rust-native database experience. Rust types guide your data model, while the ORM handles conversions and auto-generates migrations.</p>
+                </div>
             </div>
-            <div class="col">
-                <h3 class="fw-bold mb-1 fs-5">JSON APIs with OpenAPI built in</h3>
-                <p>Derive <code>JsonSchema</code> on your request and response types, and Cot generates an interactive Swagger UI automatically&nbsp;—&nbsp;no separate spec to maintain.</p>
-                {{ code_samples::JSON_CODE_SAMPLE|safe }}
+            <div class="col d-flex align-items-start">
+                {% include "icons/gauge.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Admin panel</h3>
+                    <p>Built-in admin panel is here for effortless data management. Adding new models is simple, making it perfect for rapid prototyping.</p>
+                </div>
+            </div>
+            <div class="col d-flex align-items-start">
+                {% include "icons/shield.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Security</h3>
+                    <p>Security should be the default, not an afterthought. Cot safeguards your app against modern threats, so you can focus on building, not bolting on security.</p>
+                </div>
+            </div>
+            <div class="col d-flex align-items-start">
+                {% include "icons/lightning.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Performance</h3>
+                    <p>Enjoy machine-code speed with interpreted convenience&nbsp;—&nbsp;experience full-featured development without sacrificing performance.</p>
+                </div>
+            </div>
+            <div class="col d-flex align-items-start">
+                {% include "icons/book.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Documentation</h3>
+                    <p>The documentation is a first-class citizen in Cot, making it always easy to find what you're looking for.</p>
+                </div>
+            </div>
+            <div class="col d-flex align-items-start">
+                {% include "icons/patch_check.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">Type safety</h3>
+                    <p>Cot harnesses Rust's type system to catch errors early. From ORM to the templates, every component benefits from strong typing to prevent bugs.</p>
+                </div>
+            </div>
+            <div class="col d-none d-lg-flex align-items-start">
+                {% include "icons/braces.svg" %}
+                <div>
+                    <h3 class="fw-bold mb-2 fs-4">JSON & OpenAPI</h3>
+                    <p>Cot comes with first-class JSON handling right out of the box. Simply derive JSON traits to parse data or return responses, and automatically generate Swagger UI.</p>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This adds some code samples to our homepage to tell users a bit more about how the framework looks like and make good first impression:

<img width="2050" height="2296" alt="image" src="https://github.com/user-attachments/assets/db01e043-1f66-45f2-9ac0-d3aaea69f36f" />
